### PR TITLE
Remove logo in centre of QR code

### DIFF
--- a/components/dashboard/links/Link.vue
+++ b/components/dashboard/links/Link.vue
@@ -108,7 +108,6 @@ function updateLink(link, type) {
           <PopoverContent>
             <QRCode
               :data="shortLink"
-              :image="linkIcon"
             />
           </PopoverContent>
         </Popover>


### PR DESCRIPTION
Not too useful for us, as Partner Centres may want to embed their logo in the middle, freeing up space for that