### PR TITLE
Track utm_source separately

### DIFF
--- a/components/dashboard/metrics/Index.vue
+++ b/components/dashboard/metrics/Index.vue
@@ -3,7 +3,7 @@ const { t } = useI18n()
 
 const tabs = {
   location: ['country', 'region', 'city'],
-  referer: ['referer', 'slug'],
+  referer: ['referer', 'slug', 'utmSource'],
   time: ['language', 'timezone'],
   device: ['device', 'deviceType'],
   browser: ['os', 'browser', 'browserType'],

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -136,7 +136,8 @@
       "deviceType": "Device Type",
       "os": "OS",
       "browser": "Browser",
-      "browserType": "Browser Type"
+      "browserType": "Browser Type",
+      "utmSource": "UTM Source"
     }
   },
   "links": {

--- a/i18n/locales/zh-CN.json
+++ b/i18n/locales/zh-CN.json
@@ -136,7 +136,8 @@
       "deviceType": "设备类型",
       "os": "操作系统",
       "browser": "浏览器",
-      "browserType": "浏览器类型"
+      "browserType": "浏览器类型",
+      "utmSource": "流量来源"
     }
   },
   "links": {

--- a/server/utils/access-log.ts
+++ b/server/utils/access-log.ts
@@ -34,6 +34,7 @@ export const blobsMap = {
   blob13: 'browserType',
   blob14: 'device',
   blob15: 'deviceType',
+  blob16: 'utm_source',
 } as const
 
 export type BlobsMap = typeof blobsMap
@@ -76,6 +77,9 @@ export function useAccessLog(event: H3Event) {
   const { request: { cf } } = event.context.cloudflare
   const link = event.context.link || {}
 
+  const fullUrl = new URL(getRequestURL(event))
+  const utmSource = fullUrl.searchParams.get('utm_source') || ''
+
   const isBot = cf?.botManagement?.verifiedBot
     || ['crawler', 'fetcher'].includes(uaInfo?.browser?.type || '')
     || ['spider', 'bot'].includes(uaInfo?.browser?.name?.toLowerCase() || '')
@@ -104,6 +108,7 @@ export function useAccessLog(event: H3Event) {
     browserType: uaInfo?.browser?.type,
     device: uaInfo?.device?.model,
     deviceType: uaInfo?.device?.type,
+    utm_source: utmSource,
   }
 
   if (process.env.NODE_ENV === 'production') {

--- a/server/utils/access-log.ts
+++ b/server/utils/access-log.ts
@@ -34,7 +34,7 @@ export const blobsMap = {
   blob13: 'browserType',
   blob14: 'device',
   blob15: 'deviceType',
-  blob16: 'utm_source',
+  blob16: 'utmSource',
 } as const
 
 export type BlobsMap = typeof blobsMap
@@ -108,7 +108,7 @@ export function useAccessLog(event: H3Event) {
     browserType: uaInfo?.browser?.type,
     device: uaInfo?.device?.model,
     deviceType: uaInfo?.device?.type,
-    utm_source: utmSource,
+    utmSource,
   }
 
   if (process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
Attempt to include `utm_source` as a new info(metric?)
- added into `access-logs` backend
- added into dashboard

<img width="571" alt="image" src="https://github.com/user-attachments/assets/4af7facd-b037-4ca1-bae6-448ce213013c" />

